### PR TITLE
feat/CI lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+ignore = E501
+exclude = 
+    .git,
+    __pycache__
+max-complexity = 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
         run: flake8 .
       
       - name: Run pylint
-        run: pylint qeep
+        run: pylint --disable=all --enable=duplicate-code .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Install linters
         run: pip install -r requirements.dev.txt
 
-      - name: Run flask8
-        run: flask8 .
+      - name: Run flake8
+        run: flake8 .
       
       - name: Run pylint
         run: pylint qeep

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+      
+      - name: Install linters
+        run: pip install -r requirements.dev.txt
+
+      - name: Run flask8
+        run: flask8 .
+      
+      - name: Run pylint
+        run: pylint qeep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    - id: flake8

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,15 @@
+pylint
+flake8
+cohesion
+flake8-requirements
+flake8-implicit-str-concat
+flake8-nb
+flake8-bugbear
+flake8-requests
+flake8-comprehensions
+flake8-pathlib
+flake8-string-format
+flake8-printf-formatting
+flake8-mypy
+flake8-eradicate
+vulture

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
+pre-commit
 pylint
 flake8
 cohesion

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+pip install -r requirements.dev.txt
+pip install -r requirements.txt
+pre-commit install


### PR DESCRIPTION
Adicionando analise estática de código ao repositorio,
Acabei escolhendo o flask8 por causa [desse artigo](https://towardsdatascience.com/static-code-analysis-for-python-bdce10b8d287), e deixei o pylint também pela função de codigo repetido dele.
Além disso adicionei o [pre-commit](https://pre-commit.com/) que após você instalar (`pre-commit install`) ele rota o linter pra você não comitar alguma coisa quebrada